### PR TITLE
Update NODE SDK to version 0.0.75

### DIFF
--- a/node-sdk-versions.json
+++ b/node-sdk-versions.json
@@ -1,0 +1,18 @@
+{
+    "latest_version": "0.0.74",
+    "minimum_supported_version": "0.0.50",
+    "versions": [
+        {
+            "version": "0.0.74",
+            "release_date": "2025-12-01",
+            "tag_name": "v0.0.74",
+            "download_url": "https://github.com/CyberSource/cybersource-rest-client-node/archive/refs/tags/0.0.74.zip"
+        }
+    ],
+    "repository": {
+        "owner": "CyberSource",
+        "repo": "cybersource-rest-client-node",
+        "url": "https://github.com/CyberSource/cybersource-rest-client-node"
+    },
+    "last_updated": "2026-01-09T08:30:00Z"
+}

--- a/node-sdk-versions.json
+++ b/node-sdk-versions.json
@@ -5,7 +5,7 @@
         {
             "version": "0.0.74",
             "release_date": "2025-12-01",
-            "tag_name": "v0.0.74",
+            "tag_name": "0.0.74",
             "download_url": "https://github.com/CyberSource/cybersource-rest-client-node/archive/refs/tags/0.0.74.zip"
         }
     ],

--- a/node-sdk-versions.json
+++ b/node-sdk-versions.json
@@ -1,18 +1,24 @@
 {
-    "latest_version": "0.0.74",
-    "minimum_supported_version": "0.0.50",
-    "versions": [
-        {
-            "version": "0.0.74",
-            "release_date": "2025-12-01",
-            "tag_name": "0.0.74",
-            "download_url": "https://github.com/CyberSource/cybersource-rest-client-node/archive/refs/tags/0.0.74.zip"
-        }
-    ],
-    "repository": {
-        "owner": "CyberSource",
-        "repo": "cybersource-rest-client-node",
-        "url": "https://github.com/CyberSource/cybersource-rest-client-node"
+  "latest_version": "0.0.75",
+  "minimum_supported_version": "0.0.50",
+  "versions": [
+    {
+      "version": "0.0.75",
+      "release_date": "2026-01-04",
+      "tag_name": "0.0.75",
+      "download_url": "https://github.com/CyberSource/cybersource-rest-client-node/archive/refs/tags/0.0.75.zip"
     },
-    "last_updated": "2026-01-09T08:30:00Z"
+    {
+      "version": "0.0.74",
+      "release_date": "2025-12-01",
+      "tag_name": "0.0.74",
+      "download_url": "https://github.com/CyberSource/cybersource-rest-client-node/archive/refs/tags/0.0.74.zip"
+    }
+  ],
+  "repository": {
+    "owner": "CyberSource",
+    "repo": "cybersource-rest-client-node",
+    "url": "https://github.com/CyberSource/cybersource-rest-client-node"
+  },
+  "last_updated": "2026-01-12T05:07:25Z"
 }


### PR DESCRIPTION
Automated update: CyberSource NODE REST Client SDK to version 0.0.75

- Updated `latest_version` to 0.0.75
- Updated `last_updated` timestamp
- Added version 0.0.75 to versions list
